### PR TITLE
Add api response details to fetch return value

### DIFF
--- a/src/clients/cardTokens/get/types.ts
+++ b/src/clients/cardTokens/get/types.ts
@@ -1,12 +1,13 @@
 import type { Identification } from '@src/clients/commonTypes';
 import type { MercadoPagoConfig } from '@src/mercadoPagoConfig';
+import { ApiResponse } from '@src/types';
 
 export declare type CardTokenGet = {
   id: string;
   config: MercadoPagoConfig;
 };
 
-export declare type CardTokenResponse = {
+export declare interface CardTokenResponse extends ApiResponse {
   id: string;
   card_id: string;
   first_six_digits: string;
@@ -23,7 +24,7 @@ export declare type CardTokenResponse = {
   require_esc: boolean;
   card_number_length: number;
   security_code_length: number;
-};
+}
 
 export declare type CustomerCardCardholder = {
   name: string;

--- a/src/clients/customerCards/commonTypes.ts
+++ b/src/clients/customerCards/commonTypes.ts
@@ -1,6 +1,7 @@
+import { ApiResponse } from '@src/types';
 import type { Identification } from '../commonTypes';
 
-export declare type CustomerCardResponse = {
+export declare interface CustomerCardResponse extends ApiResponse {
   id: string;
   customer_id: string;
   expiration_month: number;
@@ -15,7 +16,7 @@ export declare type CustomerCardResponse = {
   date_last_updated: string;
   user_id: string;
   live_mode: boolean;
-};
+}
 
 export declare type CustomerCardPaymentMethod = {
 	id: string;

--- a/src/clients/customers/commonTypes.ts
+++ b/src/clients/customers/commonTypes.ts
@@ -1,3 +1,4 @@
+import { ApiResponse } from '@src/types';
 import type { Identification, Phone } from '../commonTypes';
 import type { CustomerCard } from '../customerCards/create/types';
 
@@ -27,7 +28,7 @@ export declare type CustomerAddressCity = {
   name?: string;
 };
 
-export declare type Customer = {
+export declare interface CustomerResponse extends ApiResponse {
   id: string;
   email: string;
   first_name: string;
@@ -45,7 +46,7 @@ export declare type Customer = {
   cards: CustomerCard[];
   addresses: CustomerDefaultAddress[];
   live_mode: boolean;
-};
+}
 
 export declare type CustomerDefaultAddress = {
   id: string;

--- a/src/clients/customers/create/index.ts
+++ b/src/clients/customers/create/index.ts
@@ -1,9 +1,9 @@
 import { RestClient } from '@utils/restClient';
 import type { CustomerCreateRequest } from './types';
-import type { Customer } from '../commonTypes';
+import type { CustomerResponse } from '../commonTypes';
 
-export default function create({ body, config }: CustomerCreateRequest): Promise<Customer> {
-	return RestClient.fetch<Customer>(
+export default function create({ body, config }: CustomerCreateRequest): Promise<CustomerResponse> {
+	return RestClient.fetch<CustomerResponse>(
 		'/v1/customers',
 		{
 			headers: {

--- a/src/clients/customers/get/index.ts
+++ b/src/clients/customers/get/index.ts
@@ -1,9 +1,9 @@
 import { RestClient } from '@utils/restClient';
 import type { CustomerGetRequest } from './types';
-import type { Customer } from '../commonTypes';
+import type { CustomerResponse } from '../commonTypes';
 
-export default function get({ customerId, config }: CustomerGetRequest): Promise<Customer> {
-	return RestClient.fetch<Customer>(
+export default function get({ customerId, config }: CustomerGetRequest): Promise<CustomerResponse> {
+	return RestClient.fetch<CustomerResponse>(
 		`/v1/customers/${customerId}`,
 		{
 			headers: {

--- a/src/clients/customers/index.ts
+++ b/src/clients/customers/index.ts
@@ -6,7 +6,7 @@ import search from './search';
 import { CustomerCard } from '@src/clients/customerCards';
 
 import type { MercadoPagoConfig } from '@src/mercadoPagoConfig';
-import type { Customer as CustomerObj } from './commonTypes';
+import type { CustomerResponse } from './commonTypes';
 import type { CustomerCreate } from './create/types';
 import type { CustomerUpdate } from './update/types';
 import type { CustomerSearchOptions, CustomerSearchResultsPage } from './search/types';
@@ -35,7 +35,7 @@ export class Customer {
 	 *
 	 * @see {@link https://github.com/mercadopago/sdk-nodejs/blob/master/src/examples/src/customer/create/create.ts Usage Example  }.
 	 */
-	create ({ body }: CustomerCreate, requestOptions?: Options): Promise<CustomerObj> {
+	create ({ body }: CustomerCreate, requestOptions?: Options): Promise<CustomerResponse> {
 		this.config.options = { ...this.config.options, ...requestOptions };
 		return create({ body, config: this.config });
 	}
@@ -45,7 +45,7 @@ export class Customer {
 	 *
 	 * @see {@link https://github.com/mercadopago/sdk-nodejs/blob/master/src/examples/src/customer/get/get.ts Usage Example  }.
 	 */
-	get(customerId: string, requestOptions?: Options): Promise<CustomerObj> {
+	get(customerId: string, requestOptions?: Options): Promise<CustomerResponse> {
 		this.config.options = { ...this.config.options, ...requestOptions };
 		return get({ customerId, config: this.config });
 	}
@@ -55,7 +55,7 @@ export class Customer {
 	 *
 	 * @see {@link https://github.com/mercadopago/sdk-nodejs/blob/master/src/examples/src/customer/remove/remove.ts Usage Example  }.
 	 */
-	remove(customerId: string, requestOptions?: Options): Promise<CustomerObj> {
+	remove(customerId: string, requestOptions?: Options): Promise<CustomerResponse> {
 		this.config.options = { ...this.config.options, ...requestOptions };
 		return remove({ customerId, config: this.config });
 	}
@@ -65,7 +65,7 @@ export class Customer {
 	 *
 	 * @see {@link https://github.com/mercadopago/sdk-nodejs/blob/master/src/examples/src/customer/update/update.ts Usage Example  }.
 	 */
-	update({ customerId, body }: CustomerUpdate, requestOptions?: Options): Promise<CustomerObj> {
+	update({ customerId, body }: CustomerUpdate, requestOptions?: Options): Promise<CustomerResponse> {
 		this.config.options = { ...this.config.options, ...requestOptions };
 		return update({ customerId: customerId, body, config: this.config });
 	}

--- a/src/clients/customers/remove/index.ts
+++ b/src/clients/customers/remove/index.ts
@@ -1,9 +1,9 @@
 import { RestClient } from '@utils/restClient';
-import type { Customer } from '../commonTypes';
+import type { CustomerResponse } from '../commonTypes';
 import type { CustomerDeleteRequest } from './types';
 
-export default function remove({ customerId, config }: CustomerDeleteRequest): Promise<Customer> {
-	return RestClient.fetch<Customer>(
+export default function remove({ customerId, config }: CustomerDeleteRequest): Promise<CustomerResponse> {
+	return RestClient.fetch<CustomerResponse>(
 		`/v1/customers/${customerId}`,
 		{
 			headers: {

--- a/src/clients/customers/search/types.ts
+++ b/src/clients/customers/search/types.ts
@@ -1,6 +1,6 @@
 import { Paging } from '@src/clients/commonTypes';
 import type { MercadoPagoConfig } from '@src/mercadoPagoConfig';
-import type { Customer } from '../commonTypes';
+import type { CustomerResponse } from '../commonTypes';
 
 export declare type CustomerSearchRequest = {
   filters?: CustomerSearchOptions;
@@ -12,6 +12,6 @@ export declare type CustomerSearchOptions = {
 };
 
 export declare type CustomerSearchResultsPage = {
-  results: Customer[];
+  results: CustomerResponse[];
   paging: Paging;
 };

--- a/src/clients/customers/update/index.ts
+++ b/src/clients/customers/update/index.ts
@@ -1,9 +1,9 @@
 import { RestClient } from '@utils/restClient';
-import type { Customer } from '../commonTypes';
+import type { CustomerResponse } from '../commonTypes';
 import type { CustomerUpdateRequest } from './types';
 
-export default function update({ customerId, body, config }: CustomerUpdateRequest): Promise<Customer> {
-	return RestClient.fetch<Customer>(
+export default function update({ customerId, body, config }: CustomerUpdateRequest): Promise<CustomerResponse> {
+	return RestClient.fetch<CustomerResponse>(
 		`/v1/customers/${customerId}`,
 		{
 			headers: {

--- a/src/clients/identificationTypes/list/types.ts
+++ b/src/clients/identificationTypes/list/types.ts
@@ -1,13 +1,14 @@
 import type { MercadoPagoConfig } from '@src/mercadoPagoConfig';
+import { ApiResponse } from '@src/types';
 
 export declare type IdentificationTypeGet = {
   config: MercadoPagoConfig;
 };
 
-export declare type IdentificationTypeResponse = {
+export declare interface IdentificationTypeResponse extends ApiResponse {
   id: string;
   name: string;
   type: string;
   min_length: number;
   max_length: number;
-};
+}

--- a/src/clients/merchantOrders/commonTypes.ts
+++ b/src/clients/merchantOrders/commonTypes.ts
@@ -1,4 +1,6 @@
-export declare type MerchantOrder = {
+import { ApiResponse } from '@src/types';
+
+export declare interface MerchantOrderResponse extends ApiResponse {
   id: number;
   preference_id: string;
   application_id: string;
@@ -22,7 +24,7 @@ export declare type MerchantOrder = {
   total_amount: number;
   order_status: string;
   last_updated: string;
-};
+}
 
 export declare type MerchantOrderPayer = {
   id: number;

--- a/src/clients/merchantOrders/create/index.ts
+++ b/src/clients/merchantOrders/create/index.ts
@@ -1,9 +1,9 @@
 import { RestClient } from '@utils/restClient';
 import type { MerchantOrderCreateRequest } from './types';
-import type { MerchantOrder } from '../commonTypes';
+import type { MerchantOrderResponse } from '../commonTypes';
 
-export default function create({ body, config }: MerchantOrderCreateRequest): Promise<MerchantOrder> {
-	return RestClient.fetch<MerchantOrder>(
+export default function create({ body, config }: MerchantOrderCreateRequest): Promise<MerchantOrderResponse> {
+	return RestClient.fetch<MerchantOrderResponse>(
 		'/merchant_orders',
 		{
 			headers: {

--- a/src/clients/merchantOrders/get/index.ts
+++ b/src/clients/merchantOrders/get/index.ts
@@ -1,9 +1,9 @@
 import { RestClient } from '@utils/restClient';
-import { MerchantOrder } from '../commonTypes';
+import { MerchantOrderResponse } from '../commonTypes';
 import type { MerchantOrderGetRequest } from './types';
 
-export default function get({ merchantOrderId, config }: MerchantOrderGetRequest): Promise<MerchantOrder> {
-	return RestClient.fetch<MerchantOrder>(
+export default function get({ merchantOrderId, config }: MerchantOrderGetRequest): Promise<MerchantOrderResponse> {
+	return RestClient.fetch<MerchantOrderResponse>(
 		`/merchant_orders/${merchantOrderId}`,
 		{
 			headers: {

--- a/src/clients/merchantOrders/index.ts
+++ b/src/clients/merchantOrders/index.ts
@@ -3,7 +3,7 @@ import get from './get';
 import update from './update';
 import search from './search';
 import type { MercadoPagoConfig } from '@src/mercadoPagoConfig';
-import type { MerchantOrder as MerchantOrderObj } from './commonTypes';
+import type { MerchantOrderResponse } from './commonTypes';
 import type { MerchantOrderCreate } from './create/types';
 import type { MerchantOrderUpdate } from './update/types';
 import type { MerchantOrderSearchOptions, MerchantOrderSearchResultsPage } from './search/types';
@@ -26,7 +26,7 @@ export class MerchantOrder {
 	 *
 	 * @see {@link https://github.com/mercadopago/sdk-nodejs/blob/master/src/examples/src/merchantOrders/create/create.ts Usage Example  }.
 	 */
-	create({ body }: MerchantOrderCreate, requestOptions?: Options): Promise<MerchantOrderObj> {
+	create({ body }: MerchantOrderCreate, requestOptions?: Options): Promise<MerchantOrderResponse> {
 		this.config.options = { ...this.config.options, ...requestOptions };
 		return create({ body, config: this.config });
 	}
@@ -36,7 +36,7 @@ export class MerchantOrder {
 	 *
 	 * @see {@link https://github.com/mercadopago/sdk-nodejs/blob/master/src/examples/src/merchantOrders/get/get.ts Usage Example  }.
 	 */
-	get(merchantOrderId: string, requestOptions?: Options): Promise<MerchantOrderObj> {
+	get(merchantOrderId: string, requestOptions?: Options): Promise<MerchantOrderResponse> {
 		this.config.options = { ...this.config.options, ...requestOptions };
 		return get({ merchantOrderId, config: this.config });
 	}
@@ -46,7 +46,7 @@ export class MerchantOrder {
 	 *
 	 * @see {@link https://github.com/mercadopago/sdk-nodejs/blob/master/src/examples/src/merchantOrders/update/update.ts Usage Example  }.
 	 */
-	update({ merchantOrderId, body }: MerchantOrderUpdate, requestOptions?: Options): Promise<MerchantOrderObj> {
+	update({ merchantOrderId, body }: MerchantOrderUpdate, requestOptions?: Options): Promise<MerchantOrderResponse> {
 		this.config.options = { ...this.config.options, ...requestOptions };
 		return update({ merchantOrderId, body, config: this.config });
 	}

--- a/src/clients/merchantOrders/search/types.ts
+++ b/src/clients/merchantOrders/search/types.ts
@@ -1,5 +1,5 @@
 import type { MercadoPagoConfig } from '@src/mercadoPagoConfig';
-import type { MerchantOrder } from '../commonTypes';
+import type { MerchantOrderResponse } from '../commonTypes';
 
 export declare type MerchantOrderSearchRequest = {
   filters?: MerchantOrderSearchOptions;
@@ -25,7 +25,7 @@ export declare type MerchantOrderSearchOptions = {
 };
 
 export declare type MerchantOrderSearchResultsPage = {
-  results: MerchantOrder[];
+  results: MerchantOrderResponse[];
   paging: Paging;
 };
 

--- a/src/clients/merchantOrders/update/index.ts
+++ b/src/clients/merchantOrders/update/index.ts
@@ -1,9 +1,9 @@
 import { RestClient } from '@utils/restClient';
-import type { MerchantOrder } from '../commonTypes';
+import type { MerchantOrderResponse } from '../commonTypes';
 import type { MerchantOrderUpdateRequest } from './types';
 
-export default function update({ merchantOrderId, body, config }: MerchantOrderUpdateRequest): Promise<MerchantOrder> {
-	return RestClient.fetch<MerchantOrder>(
+export default function update({ merchantOrderId, body, config }: MerchantOrderUpdateRequest): Promise<MerchantOrderResponse> {
+	return RestClient.fetch<MerchantOrderResponse>(
 		`/merchant_orders/${merchantOrderId}`,
 		{
 			headers: {

--- a/src/clients/oAuth/commonTypes.ts
+++ b/src/clients/oAuth/commonTypes.ts
@@ -1,4 +1,6 @@
-export declare type OAuthResponse = {
+import { ApiResponse } from '@src/types';
+
+export declare interface OAuthResponse extends ApiResponse {
   access_token: string;
   public_key: string;
   refresh_token: string;

--- a/src/clients/paymentMethods/get/types.ts
+++ b/src/clients/paymentMethods/get/types.ts
@@ -1,10 +1,11 @@
 import type { MercadoPagoConfig } from '@src/mercadoPagoConfig';
+import { ApiResponse } from '@src/types';
 
 export declare type PaymentMethodGet = {
   config: MercadoPagoConfig;
 };
 
-export declare type PaymentMethodResponse = {
+export declare interface PaymentMethodResponse extends ApiResponse {
   id: string;
   name: string;
   payment_type_id: string;
@@ -19,7 +20,7 @@ export declare type PaymentMethodResponse = {
   accreditation_time: number;
   financial_institutions: PaymentMethodFinancialInstitutions[];
   processing_modes: string[];
-};
+}
 
 export declare type PaymentMethodSettings = {
   bin: PaymentMethodSettingsBin;

--- a/src/clients/payments/commonTypes.ts
+++ b/src/clients/payments/commonTypes.ts
@@ -1,3 +1,4 @@
+import { ApiResponse } from '@src/types';
 import type { Address, Items } from '../commonTypes';
 
 export declare type MerchantAccount = {
@@ -202,7 +203,7 @@ export declare type ThreeDSInfo = {
   creq: string;
 };
 
-export declare type PaymentsResponse = {
+export declare interface PaymentsResponse extends ApiResponse {
   id: number;
   date_created: string;
   date_approved: string;

--- a/src/clients/paymentsRefunds/commonTypes.ts
+++ b/src/clients/paymentsRefunds/commonTypes.ts
@@ -1,10 +1,12 @@
+import { ApiResponse } from '@src/types';
+
 export declare type Source = {
   id: string;
   name: string;
   type: string;
 };
 
-export declare type RefundResponse = {
+export declare interface RefundResponse extends ApiResponse {
   id: number;
   payment_id: number;
   amount: number;
@@ -17,4 +19,4 @@ export declare type RefundResponse = {
   status: string;
   reason: string;
   amount_refunded_to_payer: number;
-};
+}

--- a/src/clients/point/commonTypes.ts
+++ b/src/clients/point/commonTypes.ts
@@ -1,17 +1,18 @@
+import { ApiResponse } from '@src/types';
 import { Paging } from '../commonTypes';
 
-export declare type CancelPaymentIntentResponse = {
+export declare interface CancelPaymentIntentResponse extends ApiResponse {
   id?: string;
-};
+}
 
-export declare type PaymentIntentStatusResponse = {
+export declare interface PaymentIntentStatusResponse extends ApiResponse {
   status?: string;
   created_on?: string;
-};
+}
 
-export declare type GetPaymentIntentListResponse = {
+export declare interface GetPaymentIntentListResponse extends ApiResponse {
   events: Array<Event>;
-};
+}
 
 export declare type Event = {
   payment_intent_id: string;
@@ -19,10 +20,10 @@ export declare type Event = {
   created_on: string;
 };
 
-export declare type GetDevicesResponse = {
+export declare interface GetDevicesResponse extends ApiResponse {
   devices: Array<Device>;
   paging: Paging;
-};
+}
 
 export declare type Device = {
   payment_intent_id: string;
@@ -30,11 +31,11 @@ export declare type Device = {
   created_on: string;
 };
 
-export declare type ChangeDeviceOperatingModeResponse = {
+export declare interface ChangeDeviceOperatingModeResponse extends ApiResponse {
   operating_mode?: string;
-};
+}
 
-export declare type PaymentIntentResponse = {
+export declare interface PaymentIntentResponse extends ApiResponse {
   additional_info?: AdditionalInfo;
   amount?: number;
   description?: string;
@@ -43,7 +44,7 @@ export declare type PaymentIntentResponse = {
   payment?: Payment;
   payment_mode?: string;
   state?: string;
-};
+}
 
 export declare type PaymentIntentRequest = {
   additional_info?: AdditionalInfo;

--- a/src/clients/preApproval/commonTypes.ts
+++ b/src/clients/preApproval/commonTypes.ts
@@ -1,3 +1,5 @@
+import { ApiResponse } from '@src/types';
+
 export declare type AutoRecurringRequest = {
   frequency: number;
   frequency_type: string;
@@ -16,7 +18,7 @@ export declare type FreeTrial = {
   frequency_type: string;
 }
 
-export declare type AutoRecurringResponse = {
+export declare interface AutoRecurringResponse extends ApiResponse {
   frequency: number;
   frequency_type: string;
   transaction_amount?: number;
@@ -35,7 +37,7 @@ export declare type PreApprovalRequest = {
   status?: string;
 }
 
-export declare type SummarizedResponse = {
+export declare interface SummarizedResponse extends ApiResponse {
   charged_amount: number | null,
   charged_quantity: number | null,
   last_charged_amount: string | null
@@ -46,7 +48,7 @@ export declare type SummarizedResponse = {
   semaphore: string | null,
 }
 
-export declare type PreApprovalResponse = {
+export declare interface PreApprovalResponse extends ApiResponse {
   id: string;
   payer_id: number;
   payer_email: string;

--- a/src/clients/preApprovalPlans/commonTypes.ts
+++ b/src/clients/preApprovalPlans/commonTypes.ts
@@ -1,3 +1,5 @@
+import { ApiResponse } from '@src/types';
+
 export declare type AutoRecurring = {
   frequency: number;
   frequency_type: string;
@@ -28,7 +30,6 @@ export declare type PaymentMethod = {
   id?: string;
 };
 
-
 export declare type PreApprovalPlanRequest = {
   back_url: string;
   reason: string;
@@ -36,7 +37,7 @@ export declare type PreApprovalPlanRequest = {
   payment_methods_allowed?: PaymentMethodsAllowed;
 };
 
-export declare type PreApprovalPlanResponse = {
+export declare interface PreApprovalPlanResponse extends ApiResponse {
   id: string;
   back_url: string;
   auto_return: string;
@@ -49,4 +50,4 @@ export declare type PreApprovalPlanResponse = {
   init_point: string;
   auto_recurring: AutoRecurring;
   payment_methods_allowed: PaymentMethodsAllowed;
-};
+}

--- a/src/clients/preferences/commonTypes.ts
+++ b/src/clients/preferences/commonTypes.ts
@@ -1,4 +1,5 @@
 import type { Address, Identification, Items, Shipments } from '@src/clients/commonTypes';
+import { ApiResponse } from '@src/types';
 
 export declare type Phone = {
   area_code?: string;
@@ -96,7 +97,7 @@ export declare type PreferenceRequest = {
   tracks?: Array<Track>;
 }
 
-export declare type PreferenceResponse = {
+export declare interface PreferenceResponse extends ApiResponse {
   additional_info: string;
   auto_return: string;
   back_urls: BackUrls;
@@ -132,4 +133,4 @@ export declare type PreferenceResponse = {
   statement_descriptor: string;
   tracks: Array<Track>;
   taxes: Array<Tax>;
-};
+}

--- a/src/clients/user/get/types.ts
+++ b/src/clients/user/get/types.ts
@@ -1,10 +1,11 @@
 import type { MercadoPagoConfig } from '@src/mercadoPagoConfig';
+import { ApiResponse } from '@src/types';
 
 export declare type UserGet = {
   config: MercadoPagoConfig;
 };
 
-export declare type UserResponse = {
+export declare interface UserResponse extends ApiResponse {
   id: number;
   nickname: string;
   registration_date?: string;
@@ -34,7 +35,7 @@ export declare type UserResponse = {
   context: Context;
   registration_identifiers: string[];
   country_id: string;
-};
+}
 
 export declare type Identification = {
   number: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,3 +7,12 @@ export declare type Options = {
   timeout?: number;
   idempotencyKey?: string;
 };
+
+export declare interface ApiResponse {
+  api_response: ResponseFields;
+}
+
+export declare type ResponseFields = {
+  status: number;
+  headers: [string, string[]];
+};

--- a/src/utils/restClient/index.ts
+++ b/src/utils/restClient/index.ts
@@ -71,7 +71,6 @@ class RestClient {
 		} = config || {};
 
 		const url = RestClient.appendQueryParamsToUrl(`${BASE_URL}${endpoint}`, queryParams);
-
 		if (method && method !== 'GET') {
 			customConfig.headers = {
 				...(customConfig.headers || {}),
@@ -89,8 +88,13 @@ class RestClient {
 			});
 
 			if (response.ok) {
-				const data = await response.json() as T;
-				return data;
+				const data = await response.json();
+				const api_response = {
+					status: response.status,
+					headers: response.headers.raw(),
+				};
+				data.api_response = api_response;
+				return data as T;
 			} else {
 				throw response;
 			}

--- a/src/utils/restClient/restClient.spec.ts
+++ b/src/utils/restClient/restClient.spec.ts
@@ -210,4 +210,22 @@ describe('RestClient', () => {
 			expect(error.statusText).toBe('Bad Request');
 		}
 	});
+
+	test('Should add api_response to fetch return value', async() => {
+		(fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { 
+			url: 'url', 
+			status: 200, 
+			statusText: 'OK',
+			headers: { 'Content-Type':'application/json' } 
+		}));
+
+		const endpoint = '/test-some-other-endpoint';
+		const response: any = await RestClient.fetch(endpoint);
+
+		expect(response).toHaveProperty('success', true);
+		expect(response).toHaveProperty('api_response');
+		expect(response.api_response.status).toBe(200);
+		expect(response.api_response.headers).toEqual({ 'Content-Type':['application/json'] });
+	});
+
 });


### PR DESCRIPTION
## 📝 Description
- add `api_response` to `RestClient.fetch` return value
- rename Customer type to CustomerResponse, MerchantOrder type to MerchantOrderResponse for consistency

### ✅ Checklist:

- [X] I followed the instructions indicated in [Contribution Guidelines](CONTRIBUTING.md)
- [X] Added the necessary tests for the code or functionality that I'm working on
- [X] I ran the tests and made sure they work
- [X] My branch coverage is at least 80%
- [X] I verified the style of my code matches the one in the project